### PR TITLE
Updating faye-websocket dependency

### DIFF
--- a/slack.gemspec
+++ b/slack.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", [">= 0.7", "< 0.10"]
   spec.add_runtime_dependency "faraday_middleware", "~> 0.8"
   spec.add_runtime_dependency "multi_json", ">= 1.0.3", "~> 1.0"
-  spec.add_runtime_dependency "faye-websocket", "~> 0.9.2"
+  spec.add_runtime_dependency "faye-websocket", ">= 0.9.2"
 end


### PR DESCRIPTION
faye-websocket used to be "~> 0.9.2"
